### PR TITLE
Updating fs-extra to 0.26.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/fanciulli/v-conf/issues"
   },
   "dependencies": {
-    "fs-extra": "0.23.1",
+    "fs-extra": "^0.26.5",
     "multimap": "1.0.1"
   }
 }


### PR DESCRIPTION

Please update [fs-extra](https://npmjs.org/package/fs-extra) to version 0.26.5.

If this passes your tests you can merge it in.  If not please use this branch for changes.

 * [```4c44f48```](https://github.com/jprichardson/node-fs-extra/commit/4c44f48317845075ef59eb08df50f48fefb3ff5d) ```0.26.5```
 * [```02ca57c```](https://github.com/jprichardson/node-fs-extra/commit/02ca57c99a65d757d400b12d51eedaf821eaadda) ```Merge pull request #215 from ioncreature/patch-1```
 * [```beef585```](https://github.com/jprichardson/node-fs-extra/commit/beef585ed5c6f39447177fd8b58f7abdb6e3ee79) ```fse.copy throws error when only src and dest provided```
 * [```dc111de```](https://github.com/jprichardson/node-fs-extra/commit/dc111de48ac0cc0990c1ca0e75cac74f14dcb050) ```Merge pull request #214 from ryanmurakami/master```
 * [```b3ee155```](https://github.com/jprichardson/node-fs-extra/commit/b3ee155c126c47dc5bce6b3768dd9fddde6b47ca) ```Fixing copySync anchor tag```
 * [```5b16857```](https://github.com/jprichardson/node-fs-extra/commit/5b168579910d80101ed04b79c6401ae7c63ef323) ```Merge pull request #212 from pra85/2016```
 * [```8857682```](https://github.com/jprichardson/node-fs-extra/commit/8857682c76c61e9848c149c4ae8811c94ea4c496) ```update year to 2016```
 * [```b08fb2c```](https://github.com/jprichardson/node-fs-extra/commit/b08fb2cdd71743e68ee689012fdfb63ab59d53b3) ```readme: thought occurred that AWS is probably usin&hellip;```
 * [```cd9976c```](https://github.com/jprichardson/node-fs-extra/commit/cd9976c9eef0d3ae69dedd78015f4f9b51065d2f) ```readme: update about dropping support for Node v0.&hellip;```
 * [```3a8a6e8```](https://github.com/jprichardson/node-fs-extra/commit/3a8a6e8ec30630ed4d9f07d2e839b4be659fa609) ```changelog: tidy```
 * [```efce5fe```](https://github.com/jprichardson/node-fs-extra/commit/efce5fe00eb3a279ec0032a3c981352bad780a54) ```0.26.4```
 * [```cfcda35```](https://github.com/jprichardson/node-fs-extra/commit/cfcda358d89201eb74c92250c171c4ab6a15e8f8) ```Merge pull request #208 from chinesedfan/fix_preserveTimestamps```
 * [```38d1ab7```](https://github.com/jprichardson/node-fs-extra/commit/38d1ab7fb30e78c5102e1dfb021ed4453af60ae1) ```[copySync]fix options.preserveTimestamps. Closes #&hellip;```
 * [```4e10548```](https://github.com/jprichardson/node-fs-extra/commit/4e105480b226f22704ea0077031d06a56b3e3785) ```0.26.3```
 * [```97d6b24```](https://github.com/jprichardson/node-fs-extra/commit/97d6b24d523eb10a6c7885fdc62367513046664d) ```appveyor: remove iojs (seems to be causing errors)```


See the full [change log](https://github.com/jprichardson/node-fs-extra/compare/ddc130ea23a1a4aaf8f6aec8a90229a42edfe535...4c44f48317845075ef59eb08df50f48fefb3ff5d) for everything that changed in this release.