### PR TITLE
Added documentation for get(key,def).

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,19 @@ Returns the value associated to the key or undefined
 Example:
 
     var values=config.get('groupa.configuration');
+
+#### get(key,def)
+
+Retrieves the current value for the specified key.
+
+* key:   the key of the request configuration value. It can be absent.
+* def:   the value returned, if the the key is absent.
+
+Return the value associated to the key or the default value.
+
+Example:
+
+    var values=config.get('groupa.configuration','my default');
     
 #### delete(key)
 


### PR DESCRIPTION
Hi,

I saw the feature of providing a default value on get is missing in the documentation, I tried to add this. Feel free to modify/correct it. :)